### PR TITLE
Add interactive mockup with animated sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
-# french-learning-app
+# intouch: collectiv mockups
+
+Simple HTML prototypes exploring a tactile, retro feel for the intouch: collectiv MVP.
+
+## Usage
+
+Open `mockups/index.html` in a modern browser to explore:
+
+- A landing card that surfaces a random reflective question.
+- Animated badge-style "See Events" button.
+- Event cards that flip to reveal details and signup.
+- Smooth scrolling navigation icons.
+
+No build step is required; all assets are static.

--- a/mockups/app.js
+++ b/mockups/app.js
@@ -1,0 +1,25 @@
+const questions = [
+  "What does a slow life feel like to you?",
+  "When did you last feel truly heard?",
+  "Which sunset still lives in your memory?"
+];
+const questionEl = document.getElementById('hard-question');
+questionEl.textContent = questions[Math.floor(Math.random() * questions.length)];
+
+document.getElementById('see-events').addEventListener('click', () => {
+  document.getElementById('events').scrollIntoView({behavior: 'smooth'});
+});
+
+document.querySelectorAll('.nav-icon').forEach(link => {
+  link.addEventListener('click', (e) => {
+    e.preventDefault();
+    const target = document.querySelector(link.getAttribute('href'));
+    target.scrollIntoView({behavior: 'smooth'});
+  });
+});
+
+document.querySelectorAll('.event-card').forEach(card => {
+  card.addEventListener('click', () => {
+    card.classList.toggle('flipped');
+  });
+});

--- a/mockups/index.html
+++ b/mockups/index.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>intouch: collectiv – mockup</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <nav class="top-nav">
+    <a href="#landing" class="nav-icon" aria-label="Home">🌼</a>
+    <a href="#events" class="nav-icon" aria-label="Events">👁</a>
+    <a href="#about" class="nav-icon" aria-label="About">🤝</a>
+  </nav>
+
+  <section id="landing" class="panel landing">
+    <div class="question-card">
+      <p id="hard-question"></p>
+      <button id="see-events" class="badge-button">See Events</button>
+    </div>
+    <div class="spiral" aria-hidden="true"></div>
+  </section>
+
+  <section id="events" class="panel events">
+    <h2>Upcoming gatherings</h2>
+    <div class="event-list">
+      <div class="event-card">
+        <div class="front">
+          <h3>Slow Morning</h3>
+          <p>Aug 28, 2025</p>
+        </div>
+        <div class="back">
+          <p>Gentle journaling and tea sharing.</p>
+          <button class="signup">Sign Up</button>
+        </div>
+      </div>
+      <div class="event-card">
+        <div class="front">
+          <h3>Night of Stars</h3>
+          <p>Sep 12, 2025</p>
+        </div>
+        <div class="back">
+          <p>Outdoor stargazing, offline conversations.</p>
+          <button class="signup">Sign Up</button>
+        </div>
+      </div>
+    </div>
+    <form class="email-form">
+      <input type="email" placeholder="Email" aria-label="Email">
+      <button type="submit">Join</button>
+    </form>
+  </section>
+
+  <section id="about" class="panel about">
+    <h2>Why intouch?</h2>
+    <p>We value depth over speed and create calm spaces for introverts.</p>
+    <div class="hand-illustration" aria-hidden="true">🤲</div>
+  </section>
+
+  <footer class="footer">
+    <p>Depth over speed</p>
+  </footer>
+
+  <script src="app.js"></script>
+</body>
+</html>

--- a/mockups/styles.css
+++ b/mockups/styles.css
@@ -1,0 +1,175 @@
+:root {
+  --green: #1f4033;
+  --ochre: #c97b41;
+  --neutral: #f5f1e6;
+  --dark: #1a1f1a;
+}
+html, body {
+  margin: 0;
+  padding: 0;
+  font-family: 'Georgia', serif;
+  background: var(--neutral);
+  color: var(--dark);
+  scroll-behavior: smooth;
+}
+.top-nav {
+  position: fixed;
+  top: 0;
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  gap: 1.4rem;
+  padding: 0.6rem;
+  background: rgba(245,241,230,0.9);
+  box-shadow: 0 2px 4px rgba(0,0,0,0.05);
+  z-index: 10;
+}
+.nav-icon {
+  font-size: 1.4rem;
+  text-decoration: none;
+  transition: transform 0.3s;
+}
+.nav-icon:hover {
+  transform: rotate(-6deg) scale(1.2);
+}
+.panel {
+  min-height: 100vh;
+  padding: 5rem 1rem 2rem;
+  box-sizing: border-box;
+  position: relative;
+}
+.landing {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--green);
+  color: var(--neutral);
+}
+.question-card {
+  background: var(--neutral);
+  color: var(--dark);
+  padding: 2rem;
+  border-radius: 1.2rem;
+  box-shadow: 0 6px 20px rgba(0,0,0,0.15);
+  text-align: center;
+  position: relative;
+}
+.badge-button {
+  margin-top: 1rem;
+  padding: 0.6rem 1.2rem;
+  border: 2px solid var(--dark);
+  border-radius: 2rem;
+  background: var(--ochre);
+  color: var(--neutral);
+  font-weight: bold;
+  cursor: pointer;
+  transition: transform 0.2s;
+}
+.badge-button:hover {
+  animation: wiggle 0.4s ease-in-out;
+}
+@keyframes wiggle {
+  0%,100% {transform: rotate(0deg);} 
+  25% {transform: rotate(4deg);} 
+  75% {transform: rotate(-4deg);} 
+}
+.spiral {
+  width: 160px;
+  height: 160px;
+  border: 6px solid var(--ochre);
+  border-radius: 50%;
+  position: absolute;
+  top: 15%;
+  left: 50%;
+  transform: translateX(-50%);
+  animation: spin 12s linear infinite;
+}
+@keyframes spin {
+  from {transform: translateX(-50%) rotate(0deg);} 
+  to {transform: translateX(-50%) rotate(360deg);} 
+}
+.events {
+  background: var(--neutral);
+}
+.event-list {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+.event-card {
+  width: 220px;
+  height: 140px;
+  position: relative;
+  perspective: 1000px;
+  cursor: pointer;
+}
+.event-card .front, .event-card .back {
+  position: absolute;
+  inset: 0;
+  backface-visibility: hidden;
+  border-radius: 0.6rem;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.1);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  transition: transform 0.6s;
+}
+.event-card .front {
+  background: var(--green);
+  color: var(--neutral);
+}
+.event-card .back {
+  background: var(--ochre);
+  color: var(--neutral);
+  transform: rotateY(180deg);
+}
+.event-card.flipped .front {
+  transform: rotateY(180deg);
+}
+.event-card.flipped .back {
+  transform: rotateY(360deg);
+}
+.email-form {
+  margin-top: 2rem;
+  display: flex;
+  gap: 0.5rem;
+}
+.email-form input {
+  padding: 0.5rem;
+  border: 1px solid var(--dark);
+  border-radius: 0.4rem;
+}
+.email-form button {
+  padding: 0.5rem 1rem;
+  border: none;
+  border-radius: 0.4rem;
+  background: var(--green);
+  color: var(--neutral);
+  cursor: pointer;
+  transition: background 0.3s;
+}
+.email-form button:hover {
+  background: var(--ochre);
+}
+.about {
+  background: var(--green);
+  color: var(--neutral);
+  text-align: center;
+}
+.hand-illustration {
+  font-size: 3rem;
+  margin-top: 1rem;
+  animation: sway 5s ease-in-out infinite;
+}
+@keyframes sway {
+  0%,100% {transform: rotate(0deg);} 
+  50% {transform: rotate(7deg);} 
+}
+.footer {
+  text-align: center;
+  padding: 1rem;
+  background: var(--dark);
+  color: var(--neutral);
+}


### PR DESCRIPTION
## Summary
- add mockups illustrating landing, events, and about sections
- include CSS animations (wiggle, spin, sway) for interactive feel
- provide JS for random question, smooth scrolling, and card flips

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688f8c7b2580832480b626e05a7439bd